### PR TITLE
feat: add inverted allowlist and version bump to 1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,10 @@ mod.id=serverhats
 mod.name=Server Hats
 
 # Global dependencies
-deps.mc=1.21
+deps.mc=1.21.1
 deps.fabric_loader=0.15.11
 deps.yarn_build=7
-deps.fabric_api=0.100.6+1.21
+deps.fabric_api=0.105.0+1.21.1
 deps.flk=1.11.0+kotlin.2.0.0
 deps.silk=1.10.7
 

--- a/src/main/kotlin/dev/kikugie/serverhats/HatsConfig.kt
+++ b/src/main/kotlin/dev/kikugie/serverhats/HatsConfig.kt
@@ -20,6 +20,7 @@ class HatsConfig {
     var dispenserEquipping = true
     var mobsCanEquipHats = false
     var allowAllItems = false
+    var invertAllowList = false
     val allowedItems: MutableSet<String> = mutableSetOf(
         "#banners",
         "#beds",

--- a/src/main/kotlin/dev/kikugie/serverhats/ItemPredicateChecker.kt
+++ b/src/main/kotlin/dev/kikugie/serverhats/ItemPredicateChecker.kt
@@ -10,7 +10,7 @@ data class ItemPredicateChecker(
 ) {
     fun check(stack: ItemStack): Boolean = when {
         HatsMod.config.allowAllItems -> true
-        stack.item in items -> true
-        else -> tags.any { stack.`is`(it) }
+        stack.item in items -> HatsMod.config.invertAllowList.xor(true)
+        else -> HatsMod.config.invertAllowList.xor(tags.any { stack.`is`(it) })
     }
 }


### PR DESCRIPTION
Adds a config option to invert the allow list of items (turning it into a block list). With `invertAllowList=true`, all items are allowed to be put into the helmet slot except for the items in `allowedItems`. This is useful to prevent putting armor and other modded items in the helmet slot that shouldn't be there -- for example, Feather Falling stacks when worn as on a hat and boots.
`#minecraft:enchantable/equippable` should cover most abuse cases.

Also a band-aid fix for #1 by adding equippable+ shield to the block list.